### PR TITLE
Support preview repo from branch, tag or commit hash tag

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,9 +86,17 @@ const app = new Vue({
         if(query_repo.startsWith('http') || query_repo.startsWith('/')){
           repository_url = query_repo;
         }
-        else{
+        else if(query_repo.split('/').length === 2){
           repository_url = `https://raw.githubusercontent.com/${query_repo}/master/manifest.model.json`
         }
+        else if(query_repo.split('/').length === 3){
+          repository_url = `https://raw.githubusercontent.com/${query_repo}/manifest.model.json`
+        }
+        else{
+          alert("Unsupported repo format.")
+          throw "Unsupported repo format."
+        }
+
         repo = query_repo;
       }
       
@@ -451,8 +459,6 @@ const app = new Vue({
           }
           this.loading = false;
           this.$forceUpdate()
-
-          
       })
       .catch((e)=>{
           console.error(e)


### PR DESCRIPTION
This PR add support for repo rendering, the format for loading a repo from github are:
Let assume we have a github repo called `juglab/models`, and it contains a compiled `manifest.model.json` file, you can then use:

1. https://bioimage.io?repo=juglab/models
2. https://bioimage.io?repo=https://raw.githubusercontent.com/juglab/models/add-ilastik-app/manifest.model.json

With this PR, you can also specify the branch or commit hashtag:

3. https://bioimage.io?repo=juglab/models/mybranch
4. https://bioimage.io?repo=juglab/models/v0.1.3
5. https://bioimage.io?repo=juglab/models/79d81a1eb463528255ade4d795c98579d9a415c4

@frauzufall 
