### PR TITLE
Change models to bioimage-models

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
           <div v-if="show_models" class="mdl-grid">
             <div class="mdl-cell--6-col mdl-cel" style="padding: 0 2rem">
               <h5> # Models: {{getModelsCount()}}
-                <a id="add-model" href="https://github.com/bioimage-io/bioimage-models#how-to-contribute-new-models" target="_blank"
+                <a id="add-model" href="https://github.com/bioimage-io/bioimage-io-models#how-to-contribute-new-models" target="_blank"
                   class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
                   <i class="material-icons">add</i>
                   <div class="mdl-tooltip" data-mdl-for="add-model">
@@ -220,7 +220,7 @@
             <div class="mdl-mini-footer__left-section">
               <ul class="mdl-mini-footer__link-list">
                 <li>Adapted from <a href="https://p.migdal.pl/interactive-machine-learning-list/" target="_blank">interactive-machine-learning-list</a> by Migdał et. al.</li>
-                <li><a href="https://github.com/bioimage-io/bioimage-models" target="_blank">
+                <li><a href="https://github.com/bioimage-io/bioimage-io-models" target="_blank">
                   <img src="/assets/github.svg" style="width: 20px; height:20px;margin-right:3px;"></img>Model
                   Repository</a>
                 </li>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
           <div v-if="show_models" class="mdl-grid">
             <div class="mdl-cell--6-col mdl-cel" style="padding: 0 2rem">
               <h5> # Models: {{getModelsCount()}}
-                <a id="add-model" href="https://github.com/bioimage-io/models#how-to-contribute-new-models" target="_blank"
+                <a id="add-model" href="https://github.com/bioimage-io/bioimage-models#how-to-contribute-new-models" target="_blank"
                   class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
                   <i class="material-icons">add</i>
                   <div class="mdl-tooltip" data-mdl-for="add-model">
@@ -220,7 +220,7 @@
             <div class="mdl-mini-footer__left-section">
               <ul class="mdl-mini-footer__link-list">
                 <li>Adapted from <a href="https://p.migdal.pl/interactive-machine-learning-list/" target="_blank">interactive-machine-learning-list</a> by Migdał et. al.</li>
-                <li><a href="https://github.com/bioimage-io/models" target="_blank">
+                <li><a href="https://github.com/bioimage-io/bioimage-models" target="_blank">
                   <img src="/assets/github.svg" style="width: 20px; height:20px;margin-right:3px;"></img>Model
                   Repository</a>
                 </li>

--- a/src/main.js
+++ b/src/main.js
@@ -79,9 +79,9 @@ const app = new Vue({
     const that = this;
     that.models = []
     try {
-      let repo = 'bioimage-io/models'
+      let repo = 'bioimage-io/bioimage-models'
       const query_repo = getUrlParameter('repo')
-      let repository_url = `https://raw.githubusercontent.com/bioimage-io/models/master/manifest.model.json`
+      let repository_url = `https://raw.githubusercontent.com/bioimage-io/bioimage-models/master/manifest.model.json`
       if(query_repo){
         if(query_repo.startsWith('http') || query_repo.startsWith('/')){
           repository_url = query_repo;

--- a/src/main.js
+++ b/src/main.js
@@ -79,9 +79,9 @@ const app = new Vue({
     const that = this;
     that.models = []
     try {
-      let repo = 'bioimage-io/bioimage-models'
+      let repo = 'bioimage-io/bioimage-io-models'
       const query_repo = getUrlParameter('repo')
-      let repository_url = `https://raw.githubusercontent.com/bioimage-io/bioimage-models/master/manifest.model.json`
+      let repository_url = `https://raw.githubusercontent.com/bioimage-io/bioimage-io-models/master/manifest.model.json`
       if(query_repo){
         if(query_repo.startsWith('http') || query_repo.startsWith('/')){
           repository_url = query_repo;


### PR DESCRIPTION
I changed the `models` repo name to `bioimage-models` such that when one clone it or fork it, it will be clear that this is models for bioimage.io.