### PR TITLE
Enhance url query support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/ResourceItemCard.vue
+++ b/src/components/ResourceItemCard.vue
@@ -62,7 +62,7 @@
               >
                 <b-button
                   rounded
-                  :tag="app.url ? 'a' : 'button'"
+                  tag="a"
                   :href="app.url"
                   target="_blank"
                   @click="!app.url && app.run && app.run()"
@@ -73,7 +73,6 @@
                   <img
                     v-else-if="app.icon.startsWith('http')"
                     class="app-icon"
-                    :style="{ 'margin-top': isSafari ? '-1px' : '3px' }"
                     :src="app.icon"
                   />
                   <b-icon v-else :icon="app.icon" size="is-small"> </b-icon>
@@ -122,7 +121,6 @@
 
 <script>
 import { anonymousAnimals } from "../utils";
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 const isTouchDevice = (function() {
   try {
     document.createEvent("TouchEvent");
@@ -142,7 +140,6 @@ export default {
   },
   data() {
     return {
-      isSafari: isSafari,
       isTouchDevice: isTouchDevice
     };
   },
@@ -233,6 +230,7 @@ export default {
 .app-icon {
   width: 22px !important;
   max-width: 22px;
+  margin-top: 3px;
 }
 
 .button.is-small {

--- a/src/components/ResourceItemInfo.vue
+++ b/src/components/ResourceItemInfo.vue
@@ -51,7 +51,7 @@
       <a
         v-if="resourceItem.description.length > maxDescriptionLetters"
         @click="maxDescriptionLetters = resourceItem.description.length"
-        >...show all</a
+        >...show all.</a
       >
     </p>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,15 +110,6 @@ export function debounce(func, wait, immediate) {
   };
 }
 
-export function getUrlParameter(name) {
-  name = name.replace(/[[]/, "\\[").replace(/[\]]/, "\\]");
-  var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
-  var results = regex.exec(location.search);
-  return results === null
-    ? ""
-    : decodeURIComponent(results[1].replace(/\+/g, " "));
-}
-
 export function concatAndResolveUrl(url, concat) {
   const url1 = url.split("/");
   const url2 = concat.split("/");


### PR DESCRIPTION
This PR enhances the support for url query string, you can add `type`, `id` and `tags` to the url query string.

For example:
 * specify two tags `unet` and `pytorch`: https://bioimage.io/#/?tags=unet,pytorch
 * specify id of the item: https://bioimage.io/#/?id=UNetDA
 * specify type: https://bioimage.io/#/?type=notebook

You can combine these query strings:
 * specify type and tags: https://bioimage.io/#/?tags=viewer&type=notebook