### PR TITLE
Display doi as a badge and link to zenodo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/site.config.json
+++ b/site.config.json
@@ -130,6 +130,12 @@
       "description": "List software, web apps and utility tools"
     },
     {
+      "name": "Workflows",
+      "type": "workflow",
+      "outline_color": "rgb(255 6 6)",
+      "description": "List workflows and scripts"
+    },
+    {
       "name": "Notebooks",
       "type": "notebook",
       "outline_color": "rgb(224 188 9)",

--- a/src/components/Badges.vue
+++ b/src/components/Badges.vue
@@ -9,7 +9,14 @@
       @click="!badge.url && badge.run && badge.run()"
     >
       <b-taglist v-if="!badge.icon" attached rounded>
-        <b-tag :type="badge.label_type || 'is-dark'">{{ badge.label }}</b-tag>
+        <b-tag
+          v-if="badge.label_short && badges.length > 3"
+          :type="badge.label_type || 'is-dark'"
+          >{{ badge.label_short }}</b-tag
+        >
+        <b-tag v-else :type="badge.label_type || 'is-dark'">{{
+          badge.label
+        }}</b-tag>
         <b-tag :type="badge.ext_type || 'is-success'" v-if="badge.ext">{{
           badge.ext
         }}</b-tag>

--- a/src/components/ResourceItemCard.vue
+++ b/src/components/ResourceItemCard.vue
@@ -31,7 +31,10 @@
       </div>
       <div class="card-content">
         <div class="content">
-          <h4 class="resource-item-title" @click="showResourceItemInfo">
+          <h4
+            class="resource-item-title truncated"
+            @click="showResourceItemInfo"
+          >
             <img
               v-if="icon.type === 'img'"
               style="border-radius: 4px; background: #ffffffd0;"
@@ -45,7 +48,7 @@
               :src="'/static/anonymousAnimals/' + icon.src + '.png'"
             />
             <b-icon v-else class="item-icon" :icon="icon.src" />
-            <span>{{ resourceItem.name }}</span>
+            {{ resourceItem.name }}
           </h4>
           <div class="buttons floating-buttons">
             <app-icons
@@ -225,5 +228,11 @@ export default {
   position: absolute;
   left: 5px;
   bottom: 5px;
+}
+.truncated {
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -774,7 +774,7 @@ export default {
         // transform the RDF here
         this.prereserveDOI = depositionInfo.metadata.prereserve_doi;
         this.rdf.id = depositionInfo.metadata.prereserve_doi.doi; //doi and recid
-
+        this.rdf.config._doi = depositionInfo.metadata.prereserve_doi.doi;
         if (skipUpload) {
           this.stepIndex = 3;
           return depositionInfo;

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -722,7 +722,6 @@ export default {
               const tmp = deposit.links.latest_draft.split("/");
               depositId = parseInt(tmp[tmp.length - 1]);
               depositionInfo = await this.client.retrieve(depositId);
-              console.log("======new version===>", depositionInfo);
             }
             if (
               depositionInfo.state !== "inprogress" &&

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -464,7 +464,13 @@ export default {
           label: "Type",
           type: "select",
           placeholder: "Select resource type",
-          options: ["model", "dataset", "notebook", "application"].map(opt => {
+          options: [
+            "model",
+            "dataset",
+            "notebook",
+            "workflow",
+            "application"
+          ].map(opt => {
             return {
               text: opt,
               value: opt,

--- a/src/utils.js
+++ b/src/utils.js
@@ -218,6 +218,7 @@ export function depositionToRdf(deposition) {
     source: rdfFile, //TODO: fix for other RDF types
     links,
     config: {
+      _doi: metadata.doi,
       _deposit: deposition,
       _rdf_file: rdfFile
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -405,6 +405,7 @@
 
 <script>
 import { mapState } from "vuex";
+import spdxLicenseList from "spdx-license-list/full";
 import ResourceItemSelector from "@/components/ResourceItemSelector.vue";
 import ResourceItemList from "@/components/ResourceItemList.vue";
 import ResourceItemInfo from "@/components/ResourceItemInfo.vue";
@@ -571,10 +572,23 @@ function normalizeItem(self, item) {
   }
 
   if (item.license) {
+    console.log("=======>", spdxLicenseList[item.license]);
     item.badges.unshift({
       label: "license",
       ext: item.license,
-      ext_type: "is-info"
+      ext_type: "is-info",
+      url: spdxLicenseList[item.license] && spdxLicenseList[item.license].url
+    });
+  }
+
+  if (item.config && item.config._doi) {
+    item.badges.unshift({
+      label: item.config._doi,
+      label_type: "is-dark",
+      label_short: self.zenodoClient.isSandbox ? "Zenodo" : "DOI",
+      url: self.zenodoClient.isSandbox
+        ? `${item.config._deposit.links.html}`
+        : `https://doi.org/${item.config._doi}`
     });
   }
   if (item.type === "model" && item.co2) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -572,7 +572,6 @@ function normalizeItem(self, item) {
   }
 
   if (item.license) {
-    console.log("=======>", spdxLicenseList[item.license]);
     item.badges.unshift({
       label: "license",
       ext: item.license,


### PR DESCRIPTION
This PR implements the display of DOI as a badge, and link to zenodo.

Note that, when using sandbox mode, the generated doi is not registered, but we will link it to the zenodo deposit anyway.

Fixes https://github.com/bioimage-io/bioimage.io/issues/121