### PR TITLE
Remember user id in local storage

### DIFF
--- a/src/components/ResourceItemInfo.vue
+++ b/src/components/ResourceItemInfo.vue
@@ -124,7 +124,8 @@ export default {
         }
       }
     };
-    this.getDocs(this.resourceItem).then(focus);
+    if (this.resourceItem.documentation)
+      this.getDocs(this.resourceItem).then(focus);
   },
   computed: {
     formatedCitation: function() {

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -404,9 +404,7 @@ export default {
       }
     },
     userId() {
-      return (
-        this.client && this.client.credential && this.client.credential.user_id
-      );
+      return this.client && this.client.getUserId();
     },
     components: () => ({
       TagInputField,

--- a/src/store.js
+++ b/src/store.js
@@ -79,10 +79,8 @@ export const store = new Vuex.Store({
       );
       item.config = item.config || {};
       if (item.config._deposit) {
-        const userId =
-          state.zenodoClient &&
-          state.zenodoClient.credential &&
-          state.zenodoClient.credential.user_id;
+        const userId = state.zenodoClient && state.zenodoClient.getUserId();
+
         if (userId && item.config._deposit.owners.includes(userId)) {
           if (!item.tags.includes("editable")) item.tags.push("editable");
         }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -772,11 +772,7 @@ export default {
   },
   computed: {
     userId() {
-      return (
-        this.zenodoClient &&
-        this.zenodoClient.credential &&
-        this.zenodoClient.credential.user_id
-      );
+      return this.zenodoClient && this.zenodoClient.getUserId();
     },
     partners: function() {
       return (


### PR DESCRIPTION
This PR enables storing of user id in the browser so we can add a special tag `editable` for those items belongs to the current user, a edit icon will show so the user can click on the edit button to start updating existing deposit.

@k-dominik could you test this feature? here are steps: 1) login via the upload button 2) refresh the page and search for `editable` 3) hover on the items and you should be able to see a pencil edit icon 3) click the edit button and see how it goes