### PR TITLE
Use conceptdoi as stable id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/site.config.json
+++ b/site.config.json
@@ -43,6 +43,7 @@
   "zenodo_config": {
     "enabled": true,
     "client_id": "0Zb8YkwXBqt2zelL9WyorERRzJufdTJMgxxuibmQ",
+    "community": "bioimage-io",
     "use_sandbox": true
   },
   "attachment_table": {

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -18,7 +18,9 @@
       You are using the development mode of the upload feature, this means files
       will be uploaded to the sandbox version of Zenodo
       (https://sandbox.zenodo.org). The uploaded files can be removed from
-      Zenodo at anytime without notice.
+      Zenodo at any time without notice. This is temporary. In the future, the
+      upload feature will connect to the main Zenodo storage and allow permanent
+      storage of your data.
     </b-notification>
     <b-steps
       style="margin-top: 20px;"
@@ -31,7 +33,7 @@
         <b-field
           v-if="!client.credential"
           label="Please login or signup to Zenodo.org"
-          message="BioImage.IO uses https://zenodo.org as storage service, you will need to sign up or login to Zenodo, and allow BioImage.IO to upload files to zenodo on behave of you."
+          message="BioImage.IO uses https://zenodo.org as storage service, you will need to sign up or login to Zenodo, and allow BioImage.IO to upload files to zenodo on your behalf."
           expanded
         >
           <b-button
@@ -46,7 +48,7 @@
         <b-field
           v-else
           label="You have already logged in via Zenodo"
-          message="BioImage.IO uses https://zenodo.org as storage service, you will need to sign up or login to Zenodo, and allow BioImage.IO to upload files to zenodo on behave of you."
+          message="BioImage.IO uses https://zenodo.org as storage service, you will need to sign up or login to Zenodo, and allow BioImage.IO to upload files to zenodo on your behalf."
           expanded
         >
           <b-button
@@ -243,7 +245,11 @@
           <b-switch v-model="requestedJoinCommunity">
             Apply for listing in the
             <a
-              :href="client.baseURL + '/communities/bioimage-io/'"
+              :href="
+                client.baseURL +
+                  '/communities/' +
+                  siteConfig.zenodo_config.community
+              "
               target="_blank"
               >bioimage.io community list</a
             >
@@ -323,9 +329,10 @@
             <a :href="prereserveUrl" target="_blank">{{ prereserveUrl }}</a>
           </h2>
           <p>
-            Note: Please check carefully before publishing, it won't be easy to
-            remove items after made public. New changes will be added as a new
-            version.
+            Note: Note: Please check carefully before publishing. It is
+            generally not possible to remove items after they have been
+            published. Changes will be added as a new version, but will not
+            erase the previous version.
           </p>
         </b-notification>
 
@@ -741,6 +748,7 @@ export default {
       }
 
       this.similarDeposits = await this.client.getResourceItems({
+        community: this.siteConfig.zenodo_config.community,
         sort: "bestmatch",
         query: this.rdf.name
       });
@@ -751,12 +759,6 @@ export default {
       this.stepIndex = 2;
     },
     async publishDeposition() {
-      if (
-        !confirm(
-          "Are you sure about publish your RDF now? Please note that after publishing you won't be able to remove it. Changes to existing published deposit can only be made by publishing new versions."
-        )
-      )
-        return;
       const loadingComponent = this.$buefy.loading.open({
         container: this.$el
       });
@@ -892,7 +894,9 @@ export default {
         const metadata = rdfToMetadata(this.rdf, baseUrl, docstring);
         // this will send a email request to the admin of bioimgae-io team
         if (this.requestedJoinCommunity) {
-          metadata.communities.push({ identifier: "bioimage-io" });
+          metadata.communities.push({
+            identifier: this.siteConfig.zenodo_config.community
+          });
         }
         metadata.prereserve_doi = true; // we will generate the doi and store it in the model yaml file
         depositionInfo = await this.client.updateMetadata(

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -906,8 +906,9 @@ export default {
 
         // transform the RDF here
         this.prereserveDOI = depositionInfo.metadata.prereserve_doi;
-        this.rdf.id = depositionInfo.metadata.prereserve_doi.doi; //doi and recid
+        this.rdf.id = depositionInfo.conceptdoi; //doi and recid
         this.rdf.config._doi = depositionInfo.metadata.prereserve_doi.doi;
+        this.rdf.config._conceptdoi = depositionInfo.conceptdoi;
         if (skipUpload) {
           this.stepIndex = 3;
           return depositionInfo;

--- a/src/store.js
+++ b/src/store.js
@@ -76,8 +76,11 @@ export const store = new Vuex.Store({
         console.log("manifest already loaded");
         return;
       }
+      const siteConfig = context.state.siteConfig;
       try {
-        const items = await context.state.zenodoClient.getResourceItems({});
+        const items = await context.state.zenodoClient.getResourceItems({
+          community: siteConfig.zenodo_config.community
+        });
         console.log("All items", items);
         items.map(item => context.commit("addResourceItem", item));
       } catch (e) {
@@ -87,7 +90,6 @@ export const store = new Vuex.Store({
         );
       }
 
-      const siteConfig = context.state.siteConfig;
       const response = await fetch(manifest_url + "?" + randId());
       const repo_manifest = JSON.parse(await response.text());
       if (repo_manifest.collections && siteConfig.partners) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,17 +82,27 @@ export function rdfToMetadata(rdf, baseUrl, docstring) {
       scheme: "url"
     });
   }
-  if (rdf.config._rdf_file)
+  if (rdf.config._rdf_file) {
     // rdf.yaml or model.yaml
+    let rdf_file = rdf.config._rdf_file.startsWith("http")
+      ? rdf.config._rdf_file
+      : new URL(rdf.config._rdf_file, baseUrl).href;
+
+    debugger;
+    // When we update an existing deposit, make sure we save the relative link
+    if (rdf_file.startsWith("http") && rdf_file.includes("api/files")) {
+      rdf_file = rdf_file.split("/");
+      rdf_file = rdf_file[rdf_file.length - 1];
+      rdf_file = new URL(rdf_file, baseUrl).href;
+    }
+
     related_identifiers.push({
-      identifier: rdf.config._rdf_file.startsWith("http")
-        ? rdf.config._rdf_file
-        : new URL(rdf.config._rdf_file, baseUrl).href,
+      identifier: rdf_file,
       relation: "isCompiledBy", // compiled/created this upload
       resource_type: "other",
       scheme: "url"
     });
-  else throw new Error("`_rdf_file` key is not found in the RDF config");
+  } else throw new Error("`_rdf_file` key is not found in the RDF config");
 
   if (rdf.documentation) {
     if (rdf.documentation.includes("access_token="))
@@ -161,7 +171,9 @@ export function depositionToRdf(deposition) {
         rdfFile = rdfFile.replace("file://", deposition.links.bucket + "/");
       } else if (rdfFile.includes(`/files/`)) {
         // reset the regex
-        const zenodoFileRegex = /.*zenodo.org\/.*\/files\/(.*)/;
+        const zenodoFileRegex = rdfFile.includes("/api/files/")
+          ? /.*zenodo.org\/api\/files\/.*\/(.*)/
+          : /.*zenodo.org\/.*\/files\/(.*)/;
         const matches = zenodoFileRegex.exec(rdfFile);
         if (matches) {
           const fileName = matches[1];
@@ -182,7 +194,9 @@ export function depositionToRdf(deposition) {
         url = url.replace("file://", deposition.links.bucket + "/");
       } else if (url.includes(`${deposition.id}/files/`)) {
         // reset the regex
-        const zenodoFileRegex = /.*zenodo.org\/.*\/files\/(.*)/;
+        const zenodoFileRegex = url.includes("/api/files/")
+          ? /.*zenodo.org\/api\/files\/.*\/(.*)/
+          : /.*zenodo.org\/.*\/files\/(.*)/;
         const matches = zenodoFileRegex.exec(url);
         if (matches) {
           url = `${deposition.links.bucket}/${matches[1]}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -87,8 +87,6 @@ export function rdfToMetadata(rdf, baseUrl, docstring) {
     let rdf_file = rdf.config._rdf_file.startsWith("http")
       ? rdf.config._rdf_file
       : new URL(rdf.config._rdf_file, baseUrl).href;
-
-    debugger;
     // When we update an existing deposit, make sure we save the relative link
     if (rdf_file.startsWith("http") && rdf_file.includes("api/files")) {
       rdf_file = rdf_file.split("/");

--- a/src/utils.js
+++ b/src/utils.js
@@ -225,7 +225,7 @@ export function depositionToRdf(deposition) {
     );
   }
   return {
-    id: metadata.doi,
+    id: deposition.conceptdoi,
     name: metadata.title,
     type,
     authors: metadata.creators,
@@ -242,7 +242,8 @@ export function depositionToRdf(deposition) {
     source: rdfFile, //TODO: fix for other RDF types
     links,
     config: {
-      _doi: metadata.doi,
+      _doi: deposition.doi,
+      _conceptdoi: deposition.conceptdoi,
       _deposit: deposition,
       _rdf_file: rdfFile
     }
@@ -266,6 +267,7 @@ export class ZenodoClient {
     this.credential = null;
     try {
       this.lastUserId = localStorage.getItem("zenodo_user_id");
+      if (this.lastUserId) this.lastUserId = parseInt(this.lastUserId);
       let lastCredential = localStorage.getItem("zenodo_credential");
       if (lastCredential) {
         this.credential = JSON.parse(lastCredential);
@@ -278,7 +280,6 @@ export class ZenodoClient {
       }
     } catch (e) {
       console.error("Failed to reset zenodo_credential");
-      localStorage.removeItem("zenodo_credential");
     }
   }
 
@@ -289,6 +290,11 @@ export class ZenodoClient {
   logout() {
     return new Promise((resolve, reject) => {
       this.credential = null;
+      try {
+        localStorage.removeItem("zenodo_credential");
+      } catch (e) {
+        console.error("Failed to reset zenodo_credential");
+      }
       const loginWindow = window.open(`${this.baseURL}/logout`, "Logout");
       try {
         loginWindow.focus();

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -514,14 +514,14 @@ function normalizeItem(self, item) {
     });
   }
 
-  if (item.config && item.config._doi) {
+  if (item.config && item.config._conceptdoi) {
     item.badges.unshift({
-      label: item.config._doi,
+      label: item.config._conceptdoi,
       label_type: "is-dark",
       label_short: self.zenodoClient.isSandbox ? "Zenodo" : "DOI",
       url: self.zenodoClient.isSandbox
         ? `${item.config._deposit.links.html}`
-        : `https://doi.org/${item.config._doi}`
+        : `https://doi.org/${item.config._conceptdoi}`
     });
   }
   if (item.type === "model" && item.co2) {
@@ -671,7 +671,8 @@ export default {
             item =>
               item.config &&
               item.config._deposit &&
-              item.config._deposit.id === zenodoId
+              (item.config._deposit.id === zenodoId ||
+                item.config._deposit.conceptrecid === zenodoId)
           )[0];
           if (matchedItem) this.$route.query.id = matchedItem.id;
           else alert("Oops, resource item not found: " + this.resourceId);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1292,6 +1292,6 @@ body {
 }
 
 form {
-  max-width: 100%;
+  max-width: 100% !important;
 }
 </style>


### PR DESCRIPTION
This PR supports using the conceptdoi which is version independent doi as RDF id, and store `config._conceptdoi`.
It also fixes a logout issue along with the edit button.