### PR TITLE
Upgrade imjoy-core to 0.13.80 to fix webpython mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/bioEngine.js
+++ b/src/bioEngine.js
@@ -33,7 +33,7 @@ export async function setupBioEngine(updateDevMenu) {
   }
   window
     .loadImJoyBasicApp({
-      version: "0.13.78",
+      version: "0.13.80",
       process_url_query: true,
       show_window_title: false,
       show_progress_bar: true,


### PR DESCRIPTION
This PR upgrades imjoy-core to support web-python with the latest pyodide. This enables loading bioengine.spec directly for validation and packaging.

Here is an example plugin
```html
<config lang="json">
{
  "name": "TestBioImageIO.SPEC",
  "type": "web-python",
  "version": "0.1.0",
  "description": "[TODO: describe this plugin with one sentence.]",
  "tags": [],
  "ui": "",
  "cover": "",
  "inputs": null,
  "outputs": null,
  "flags": [],
  "icon": "extension",
  "api_version": "0.1.8",
  "env": "",
  "permissions": [],
  "requirements": ["bioimageio.spec"],
  "dependencies": []
}
</config>

<script lang="python">
from imjoy import api
from bioimageio.spec import nodes, schema
        
class ImJoyPlugin():
    def setup(self):
        api.log('initialized')

    def run(self, ctx):
        data = {
            "name": "input_1",
            "description": "Input 1",
            "data_type": "float32",
            "axes": "xyc",
            "shape": [128, 128, 3],
            "preprocessing": [
                {
                    "name": "scale_range",
                    "kwargs": {"max_percentile": 99, "min_percentile": 5, "mode": "per_sample", "axes": "xy"},
                }
            ],
        }
        validated_data = schema.InputTensor().load(data)
        api.alert(str(validated_data))

api.export(ImJoyPlugin())
</script>

```

To test it in bioimage.io, you can enable the dev mode by using https://bioimage.io/#/?dev=1 , then open the ImJoy Fiddle plugin under the ImJoy Icon menu. Copy and paste the above code and run it in the code editor:

<img width="1331" alt="Screen Shot 2021-07-12 at 10 09 02 AM" src="https://user-images.githubusercontent.com/478667/125259273-73118d00-e2ff-11eb-80c6-0f9fa92ba406.png">

@FynnBe 