### PR TITLE
Don't break for invalid cover image

### DIFF
--- a/src/components/CitationInputField.vue
+++ b/src/components/CitationInputField.vue
@@ -87,6 +87,8 @@ export default {
   },
   created() {
     this.value = this.item.value;
+    if (typeof this.value === "string") this.value = [{ text: this.value }];
+    if (this.value && !Array.isArray(this.value)) this.value = [this.value];
     this.value = this.value || [];
     if (this.value.length <= 0) {
       this.value.push({

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,10 +201,12 @@ export function depositionToRdf(deposition) {
         if (matches) {
           url = `${deposition.links.bucket}/${matches[1]}`;
         } else {
-          throw new Error("Invalid file identifier: " + idf.identifier);
+          console.error(
+            "Invalid cover image file identifier: " + idf.identifier
+          );
         }
       } else {
-        throw new Error("Invalid file identifier: " + idf.identifier);
+        console.error("Invalid cover image file identifier: " + idf.identifier);
       }
       covers.push(url);
     } else if (


### PR DESCRIPTION
The card with invalid cover image won't show, this PR allows showing the card without the cover image.

https://github.com/bioimage-io/bioimage.io/issues/147

Also includes a fix for improving the robustness in the citation field.