### PR TITLE
Update the form with an RDF file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -135,6 +135,7 @@
           <br />
           <b-field
             label="Optionally, you can update the form with values from an local RDF file"
+            message="Note: This operation will overwrite the values in the above RDF form, if you have further changes to make, please load the local RDF file first, then make changes in the form."
             expanded
           >
             <b-upload


### PR DESCRIPTION
This PR adds a new button to the end of the RDF form, so one can update the RDF form with a local file. One use case is that when we want to edit a deposit with the edit button, to replace the RDF file, we can use this button.

 A related issue was asked by @esgomezm