### PR TITLE
Fix Issue #101 - Docs site icon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,12 +9,12 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="description" content="ImJoy Docs">
   <meta name="author" content="ImJoy Team">
-  <link rel="apple-touch-icon" sizes="180x180" href="static/icons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="static/icons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="static/icons/favicon-16x16.png">
-  <link rel="mask-icon" href="static/icons/safari-pinned-tab.svg" color="#5bbad5">
-  <link rel="shortcut icon" href="static/icons/favicon.ico" type="image/x-icon">
-  <link rel="icon" href="static/icons/favicon.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon-16x16.png">
+  <link rel="mask-icon" href="/static/icons/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" href="/static/icons/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/static/icons/favicon.ico" type="image/x-icon">
   <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="https://imjoy-team.github.io/imjoy-docs/static/vue.css" />
   <link rel="stylesheet" href="https://imjoy-team.github.io/imjoy-docs/static/style.css" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,12 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="description" content="ImJoy Docs">
   <meta name="author" content="ImJoy Team">
-  <link rel="icon" href="https://imjoy.io/static/icons/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" sizes="180x180" href="static/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="static/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="static/icons/favicon-16x16.png">
+  <link rel="mask-icon" href="static/icons/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" href="static/icons/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="static/icons/favicon.ico" type="image/x-icon">
   <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="https://imjoy-team.github.io/imjoy-docs/static/vue.css" />
   <link rel="stylesheet" href="https://imjoy-team.github.io/imjoy-docs/static/style.css" />


### PR DESCRIPTION
Updates the favicon and browser tab icons in the docs site to use the bioimage.io giraffe logo headers, intended to work with multiple browsers. Fixes #101