### PR TITLE
Switch to zenodo production

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -52,9 +52,10 @@
   },
   "zenodo_config": {
     "enabled": true,
-    "client_id": "0Zb8YkwXBqt2zelL9WyorERRzJufdTJMgxxuibmQ",
+    "sandbox_client_id": "0Zb8YkwXBqt2zelL9WyorERRzJufdTJMgxxuibmQ",
+    "production_client_id": "nO6VNWAiRjklxcVx0roedRnQncQTyEMRkTDzg6kd",
     "community": "bioimage-io",
-    "use_sandbox": true
+    "use_sandbox": false
   },
   "attachment_table": {
     "columns": [

--- a/src/store.js
+++ b/src/store.js
@@ -25,6 +25,9 @@ const zenodoBaseURL = siteConfig.zenodo_config.use_sandbox
   ? "https://sandbox.zenodo.org"
   : "https://zenodo.org";
 
+const client_id = siteConfig.zenodo_config.use_sandbox
+  ? siteConfig.zenodo_config.sandbox_client_id
+  : siteConfig.zenodo_config.production_client_id;
 export const store = new Vuex.Store({
   state: {
     loadedUrl: null,
@@ -34,7 +37,7 @@ export const store = new Vuex.Store({
     zenodoClient: siteConfig.zenodo_config.enabled
       ? new ZenodoClient(
           zenodoBaseURL,
-          siteConfig.zenodo_config.client_id,
+          client_id,
           siteConfig.zenodo_config.use_sandbox
         )
       : null,

--- a/src/utils.js
+++ b/src/utils.js
@@ -404,7 +404,11 @@ export class ZenodoClient {
     });
     console.log("Get items from URL: ", resourceItems, url);
     const items = resourceItems.filter(item => !!item);
-    items.total = results.aggregations.access_right.buckets[0].doc_count;
+    if (results.aggregations.access_right.buckets.length > 0) {
+      items.total = results.aggregations.access_right.buckets[0].doc_count;
+    } else {
+      items.total = 0;
+    }
     return items;
   }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,7 +11,11 @@
         aria-close-label="Close notification"
         role="alert"
       >
-        We are currently upgrading the website, to access all the previous models, go to <a href="https://deploy-preview-199--bioimage.netlify.app/#/">https://deploy-preview-199--bioimage.netlify.app/</a>.
+        We are currently upgrading the website, to access all the previous
+        models, go to
+        <a href="https://deploy-preview-199--bioimage.netlify.app/#/"
+          >https://deploy-preview-199--bioimage.netlify.app/</a
+        >.
       </b-notification>
       <div class="hero-body" style="position: relative;">
         <img

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,6 +5,14 @@
       class="hero is-link is-fullheight is-fullheight-with-navbar"
       style="max-height: 1024px!important;height:100%;min-height:640px;"
     >
+      <b-notification
+        type="is-warning"
+        has-icon
+        aria-close-label="Close notification"
+        role="alert"
+      >
+        We are currently upgrading the website, to access all the previous models, go to <a href="https://deploy-preview-199--bioimage.netlify.app/#/">https://deploy-preview-199--bioimage.netlify.app/</a>.
+      </b-notification>
       <div class="hero-body" style="position: relative;">
         <img
           class="background-img"


### PR DESCRIPTION
This PR switch the backend server from the sandbox zenodo (https://sandbox.zenodo.org) to production zenodo (https://zenodo.org). This switch also means that we will need to re-upload all the models and take the chance curate the models.

Note: Since the production zenodo is meant for the actual publication, all the published items are not removable, so we need to be careful about what to upload.