### PR TITLE
Add code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,8 @@ The source code of BioImage.IO platform is released under MIT license. The conte
 ## Citation
 If you find BioImage.IO helpful for your research please consider cite BioImage.IO: [TODO]
 
+## Code of Conduct
+All the developers, contributors and community members of the BioImage.IO are recommended to read our [Code of Conduct](https://bioimage.io/docs/#/CODE_OF_CONDUCT).
+
 ## User Agreement
 By using the BioImage.IO website and/or viewing material on the website, you agree to become bound by the terms of this [User Agreement](./docs/user_agreement.md). If you do not agree to the Disclaimer, Terms of Use, and Privacy Statements of this User Agreement, do not use this website or any portion thereof in any form or manner.

--- a/docs/CODE_OF_CONDUCT
+++ b/docs/CODE_OF_CONDUCT
@@ -1,0 +1,135 @@
+
+# Code of Conduct
+
+## Introduction
+This code of conduct applies to all spaces managed by the BioImage.IO project, including all public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channel used by our community. The BioImage.IO project does not organise in-person events, however events related to our community should have a code of conduct similar in spirit to this one.
+
+This code of conduct should be honored by everyone who participates in the BioImage.IO community formally or informally, or claims any affiliation with the project, in any project-related activities and especially when representing the project, in any role.
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. Please try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the surrounding community.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1]
+and [the Code of Conduct of napari](https://napari.org/community/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Code of Conduct
 
 ## Introduction

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -121,14 +121,10 @@ community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1]
-and [the Code of Conduct of napari](https://napari.org/community/code_of_conduct.html).
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at [v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) and [the Code of Conduct of napari](https://napari.org/community/code_of_conduct.html).
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+[FAQ](https://www.contributor-covenant.org/faq).

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,3 +15,4 @@
   - [How-tos Guide](/community_partners/how-tos_guide)
   - [BioImage.IO Manifest File](/community_partners/manifest-format.md)
 * [User Agreement](/user_agreement.md)
+* [Code of Conduct](/CODE_OF_CONDUCT.md)

--- a/site.config.json
+++ b/site.config.json
@@ -38,7 +38,7 @@
     },
     { "label": "Deploys By Netlify",
       "tooltip": "This site is powered by Netlify",
-      "logo": "https://www.netlify.com/img/global/badges/netlify-color-dark.svg", 
+      "logo": "https://www.netlify.com/img/global/badges/netlify-color-accent.svg", 
       "url": "https://www.netlify.com"
     }
   ],


### PR DESCRIPTION
This PR adds a code of conduct adapted from the Contributor Covenant, version 2.1, available at [v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) and [the Code of Conduct of napari](https://napari.org/community/code_of_conduct.html).