### PR TITLE
Add netlify for trigger CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Local Netlify folder
+.netlify

--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -1,0 +1,9 @@
+
+## Development
+ * Install netlify cli
+ * Run `netlify login` and `netlify link`
+ * Create a personal access token in Github with `repository` and `workflow` scopes.
+ * To start a local server run:
+    ```
+    GITHUB_TOKEN=xxx netlify dev --live
+    ```

--- a/netlify/functions/bioimageiobot.js
+++ b/netlify/functions/bioimageiobot.js
@@ -1,0 +1,145 @@
+// This netlify function allows trigger github actions with an http request,
+// for example: https://bioimage.netlify.app/.netlify/functions/bioimageiobot?action=notify&source=https://zenodo.org/api/files/3f422e1b-a64e-40d3-89d1-29038d2f405d/rdf.yaml
+const request = require('request');
+const yaml = require('js-yaml');
+const workflowId = "auto_update_main.yaml"
+
+function dispatch_workflow(workflowId, token) {
+    return new Promise((resolve, reject) => {
+        const options = {
+            url: `https://api.github.com/repos/bioimage-io/collection-bioimage-io/actions/workflows/${workflowId}/dispatches`,
+            method: 'POST',
+            headers: {"Accept": "application/vnd.github.v3+json", "Authorization": `token ${token}`, 'user-agent': 'bioimage-bot'},
+            body: JSON.stringify({
+                'ref' : 'main'
+            })
+        };
+
+        request(options, function(err, res, body) {
+            if(err){
+                reject(`Invalid response (code: ${res.statusCode}, ${res})`);
+                return
+            }
+            if(res.statusCode === 204) {
+                resolve()
+            }     
+            else{
+                console.log(body)
+                reject(`Invalid response (code: ${res.statusCode}, ${body})`);
+            }
+        });
+    })
+}
+
+function check_waiting_workflow(workflowName, token) {
+    return new Promise((resolve, reject) => {
+        const url = `https://api.github.com/repos/bioimage-io/collection-bioimage-io/actions/runs?status=waiting&branch=main`
+        const options = {
+            url,
+            method: 'GET',
+            headers: {"Accept": "application/vnd.github.v3+json", "Authorization": `token ${token}`, 'user-agent': 'bioimage-bot'},
+        };
+
+        request(options, function(err, res, body) {
+            if(err){
+                reject(`Invalid response (code: ${res.statusCode}, ${res})`);
+                return
+            }
+            try{
+                if(res.statusCode === 200) {
+                    const ret = JSON.parse(body)
+                    const waiting_workflow = ret.workflow_runs.filter(w => {
+                        return w.name === workflowName && w.status === "waiting"
+                    })
+                    console.log(`Waiting workflows (name=${workflowName}): ${waiting_workflow.length}`)
+                    resolve(waiting_workflow.length)
+                }     
+                else{
+                    console.log(body)
+                    reject(`Invalid response (code: ${res.statusCode}, ${body})`);
+                }
+            }
+            catch(e){
+                reject(e)
+            }
+        });
+    })
+}
+
+
+
+function get(url){
+    return new Promise((resolve, reject) => {
+        request({
+            url,
+            method: "GET",
+            headers: {'user-agent': 'bioimage-bot'},
+        }, function(err, res, body) {
+            if(err){
+                reject(`Invalid response (code: ${res.statusCode}, ${res})`);
+                return
+            }
+            if(res.statusCode === 200) {
+                resolve(body)
+            }     
+            else{
+                console.log(body)
+                reject(`Invalid response (code: ${res.statusCode}, ${body})`);
+            }
+        })
+    })
+}
+
+exports.handler = async function(event, context) {
+    const source = event.queryStringParameters.source
+    const action = event.queryStringParameters.action
+    if(!action){
+        return { statusCode: 500, body: "Please specify an action"}
+    }
+    if(action === 'notify'){
+         // const resource_id = event.queryStringParameters.id
+        const { GITHUB_TOKEN } = process.env;
+        if(!GITHUB_TOKEN){
+            return { statusCode: 500, body: "server function is not configured properly (requires GITHUB_TOKEN env variable)"}
+        }
+        if(!source){
+            return { statusCode: 403, body: "Please provide a RDF source URL in the query string"}
+        }
+        if(!source.startsWith("http")){
+            return { statusCode: 403, body: "Invalid RDF source url, it must be a valid URL"}
+        }
+        const sourceContent = await get(source)
+        if(source.split("?")[0].endsWith(".yaml")){
+            let resource;
+            try{
+                resource = yaml.load(sourceContent)
+                // TODO: check if the resource is worth to to run a workflow
+            }
+            catch(e){
+                return { statusCode: 403, body: `Failed to parse the source file: ${e}`}
+            }
+        }
+        else{
+            return { statusCode: 403, body: "Invalid RDF source file type, only yaml is supported for now"}
+        }
+        // check if the workflow is already waiting in the queue
+        // if(await check_waiting_workflow("generate auto-update PRs", GITHUB_TOKEN) > 0){
+        //     return {
+        //         statusCode: 200,
+        //         body: JSON.stringify({source, success: true, new_workflow: false, message: "A previous workflow is already waiting in the queue"})
+        //     };
+        // }
+        await dispatch_workflow(workflowId, GITHUB_TOKEN)
+        return {
+            statusCode: 200,
+            body: JSON.stringify({source, success: true, new_workflow: true, message: "A new workflow run is dispatched."})
+        };
+    }
+    else{
+        return {
+            statusCode: 403,
+            body: `Unsupported action: ${action}`
+        };
+    }
+   
+};

--- a/netlify/functions/rebuild.js
+++ b/netlify/functions/rebuild.js
@@ -1,6 +1,0 @@
-exports.handler = async function(event, context) {
-    return {
-        statusCode: 200,
-        body: JSON.stringify(event)
-    };
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioimage",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
This PR adds a serverless function running with netlify, this enables triggering CI in the [collection repo](https://github.com/bioimage-io/collection-bioimage-io) from an http request ([example](https://bioimage.netlify.app/.netlify/functions/bioimageiobot?action=notify&source=https://zenodo.org/api/files/3f422e1b-a64e-40d3-89d1-29038d2f405d/rdf.yaml)). This allows us to dispatch a workflow in the collection repo to detect changes when a user uploaded a new RDF from the website.

cc @FynnBe 