### PR TITLE
Add source field

### DIFF
--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -705,12 +705,6 @@ export default {
           help:
             "The maintainers who maintain this resource item. Importantly, the first maintainer will be contacted for the approval process to the BioImage.IO"
         },
-        // {
-        //   label: "Source",
-        //   placeholder: "A doi or URL to the source of the item",
-        //   isRequired: false,
-        //   value: this.rdf.version
-        // },
         {
           label: "Version",
           placeholder: "Version in MAJOR.MINOR.PATCH format(e.g. 0.1.0)",
@@ -847,7 +841,7 @@ export default {
         description: "Description",
         version: "Version",
         license: "License",
-        // source: "Source",
+        source: "Source",
         git_repo: "Git Repository",
         tags: "Tags",
         links: "Links",

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -767,6 +767,13 @@ export default {
           isRequired: false
         },
         {
+          label: "Source",
+          placeholder: "source",
+          value: this.rdf.source,
+          isRequired: false,
+          help: "The source url of your deposit (optional)"
+        },
+        {
           label: "Links",
           type: "tags",
           value: this.rdf.links,


### PR DESCRIPTION
For datasets, we expose the source field in the upload form. For simplicity, we show this field for disregard the types.

cc @esgomezm 