### PR TITLE
Switch bioengine model whitelist

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -756,10 +756,9 @@ export default {
 
       const self = this;
       const response = await fetch(
-        "https://raw.githubusercontent.com/bioimage-io/bioengine-model-runner/main/manifest.bioengine.yaml"
+        "https://raw.githubusercontent.com/bioimage-io/bioengine-model-runner/gh-pages/manifest.bioengine.json"
       );
-      const yamlStr = await response.text();
-      const bioEngineManifest = yaml.load(yamlStr);
+      const bioEngineManifest = await response.json();
       const bioEngineConfigs = {};
       for (let conf of bioEngineManifest.collection)
         if (conf.id) bioEngineConfigs[conf.id] = conf;


### PR DESCRIPTION
We have now improved the bioengine with native triton model formats, with that we were able to generate [a list of supported models](https://github.com/bioimage-io/bioengine-model-runner/blob/gh-pages/manifest.bioengine.yaml) automatically. 

Note: This means we will deprecate the previous way of masking out unsupported models (i.e. using https://github.com/bioimage-io/bioengine-model-runner/blob/main/manifest.bioengine.yaml )

I will remove the old file from the main branch.

cc @constantinpape 