### PR TITLE
fixed wording in spash, fixed capitalization of ilastik

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -47,7 +47,7 @@
   "splash_title": "BioImage Model Zoo",
   "splash_subtitle": "Advanced AI models in one-click",
   "splash_feature_list": [
-    "Integrate with Fiji, Ilastik, ImJoy and more",
+    "Integrated with Fiji, ilastik, ImJoy and more",
     "Try model instantly with BioEngine",
     "Contribute your models via Github",
     "Link models to datasets and applications"


### PR DESCRIPTION
It just occurred to me that the we _are_ in fact integrated with the tools listed, so that should be reflected in the wording.

Also ilastik is always spelled all lowercase.