### PR TITLE
Center community partners on view

### DIFF
--- a/src/components/PartnersNew.vue
+++ b/src/components/PartnersNew.vue
@@ -2,8 +2,13 @@
   <div class="partners-component">
     <h2>Community Partners</h2>
     <div class="partners-list">
-      <div v-for="p in partners" :key="p.name" class='partners-list-item' @click='switchPartner(p)'>
-        <img :src="p.logo || p.icon" :alt="p.name">
+      <div
+        v-for="p in partners"
+        :key="p.name"
+        class="partners-list-item"
+        @click="switchPartner(p)"
+      >
+        <img :src="p.logo || p.icon" :alt="p.name" />
         <p>{{ p.name }}</p>
       </div>
     </div>

--- a/src/components/PartnersNew.vue
+++ b/src/components/PartnersNew.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="partners-component">
+    <h2>Community Partners</h2>
+    <div class="partners-list">
+      <div v-for="p in partners" :key="p.name" class='partners-list-item' @click='switchPartner(p)'>
+        <img :src="p.logo || p.icon" :alt="p.name">
+        <p>{{ p.name }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Partners",
+  props: {
+    partners: {
+      type: Array,
+      default: null
+    }
+  },
+  data() {
+    return {
+      icon_width: 140,
+      selectedPartnerIndex: 0,
+      items2Show: window.innerWidth / 140
+    };
+  },
+  mounted() {
+    window.addEventListener("resize", this.updateSize);
+    window.dispatchEvent(new Event("resize"));
+  },
+  beforeDestroy() {
+    window.removeEventListener("resize", this.updateSize);
+  },
+  methods: {
+    updateSize() {
+      if (window.innerWidth < 512) {
+        this.icon_width = 80;
+      } else {
+        this.icon_width = 140;
+      }
+      this.items2Show = window.innerWidth / this.icon_width;
+      this.$forceUpdate();
+    },
+    switchPartner(partner) {
+      this.$emit("switchPartner", partner);
+    }
+  }
+};
+</script>
+<style scoped>
+.partners-component > h2 {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #2196f3;
+}
+.partners-component {
+  width: 100%;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+  background-color: white;
+  text-align: center;
+  right: 0px;
+  left: 0px;
+}
+
+.partners-list {
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.partners-list-item {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 6rem;
+  cursor: pointer;
+}
+
+.partners-list-item > img {
+  height: 2.5rem;
+  width: auto;
+}
+
+.partners-list-item > p {
+  color: #2196f3;
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+}
+
+@media screen and (max-width: 500px) {
+  .partners-list {
+    flex-wrap: wrap;
+  }
+
+  .partners-list-item {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -325,7 +325,6 @@ import ResourceItemSelector from "@/components/ResourceItemSelector.vue";
 import ResourceItemList from "@/components/ResourceItemList.vue";
 import ResourceItemInfo from "@/components/ResourceItemInfo.vue";
 import AttachmentsComponent from "@/components/Attachments.vue";
-// import PartnersComponent from "@/components/Partners.vue";
 import PartnersComponent from "@/components/PartnersNew.vue";
 import CommentBox from "@/components/CommentBox.vue";
 import MarkdownComponent from "@/components/Markdown.vue";

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,12 +12,6 @@
           :src="selectedPartner.background_image"
         />
         <img class="background-img" v-else :src="siteConfig.background_image" />
-        <partners-component
-          v-if="partners"
-          style="position: absolute;bottom: 0px;"
-          :partners="partners"
-          @switchPartner="switchPartner"
-        ></partners-component>
 
         <div
           class="container"
@@ -78,11 +72,16 @@
           >
         </div>
       </div>
+      <partners-component
+        v-if="partners"
+        :partners="partners"
+        @switchPartner="switchPartner"
+      ></partners-component>
     </section>
 
-    <span ref="search_anchor"></span>
-    <br />
-    <section style="margin-top: -30px;opacity: 0.6;">
+    <!-- <span ref="search_anchor"></span>
+    <br /> -->
+    <section style="opacity: 0.6;">
       <b-progress :value="progress"></b-progress>
     </section>
     <br />
@@ -326,7 +325,8 @@ import ResourceItemSelector from "@/components/ResourceItemSelector.vue";
 import ResourceItemList from "@/components/ResourceItemList.vue";
 import ResourceItemInfo from "@/components/ResourceItemInfo.vue";
 import AttachmentsComponent from "@/components/Attachments.vue";
-import PartnersComponent from "@/components/Partners.vue";
+// import PartnersComponent from "@/components/Partners.vue";
+import PartnersComponent from "@/components/PartnersNew.vue";
 import CommentBox from "@/components/CommentBox.vue";
 import MarkdownComponent from "@/components/Markdown.vue";
 


### PR DESCRIPTION
This pull request fixes #177 where the component's content is off-center.

### Centering
The changes revolve around a new single-file component, _PartnersNew.vue_. The layout and styling have been preserved from the original, although the new component uses scoped native CSS for now to prevent any CSS conflicts with styles that I'm not aware of. 

Additionally, __Home.vue__ has been modified slightly so that the Partners component does not rely on absolute positioning within the hero section. This helps to simplify the HTML layout.

Media queries have been added to the component style to allow the partners list to wrap in devices with narrower viewports.

The original functionality of the partners list items has been maintained, including filtering by software/partner as well as the hero banners changing on click.

@oeway and maintainers, I hope this helps improve the site layout a little bit.