### PR TITLE
Support custom size for images in markdown

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,20 @@
         theme: 'classic',
         tabComments: true,
         tabHeadings: true
+      },
+      markdown: {
+        renderer: {
+          image(src, title, alt) {
+            // resolve src to basePath
+            // e.g. http://localhost:8080/docs#/user_guide/a.jpg -> docs/user_guide/a.jpg
+            if(!src.startsWith('http') && !src.startsWith('/')){
+              const url = new URL(src, window.location.href.replace(/#\//, '/')); // remove hash
+              src = url.pathname;
+            }
+            const [width, height] = (title && title.startsWith('=')) ? title.slice(1).split('x').map(v => v.trim()).filter(Boolean) : [];
+            return `<img src="${src}" alt="${alt}"${width ? ` width="${width}"` : ''}${height ? ` height="${height}"` : ''}>`;
+          }
+        }
       }
     };
   </script>


### PR DESCRIPTION
@carlosuc3m 

For the images in the docs, please use standard markdown syntax to add images instead of html tags. We have supported custom size now:
`![](./download_model_packager.jpg "=100x80")`

If you want to use html tag for this, you will need to set the relative path to include the subfolder, e.g.: `<img src="./user_guide/download_model_packager.jpg">`.



