### PR TITLE
Updated the Resources for Developers

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,8 +15,6 @@
   - [Upload models through Zenodo](/contribute_models/contribute_zenodo.md)
 * [Other contributions](/contribute_others/README.md)
 * [Resources for developers](/resources_developers/README.md)
-  - [Python BioImageIO core package](pythoncorepackage)
-  - [Java BioImageIO library](javacorepackage)
 * [Consumer Software](/consumer_software/README.md)
   - [Tutorials](/consumer_software/tutorials.md)
   - [Model Runner](/consumer_software/model_runner.md)

--- a/docs/resources_developers/README.md
+++ b/docs/resources_developers/README.md
@@ -1,1 +1,19 @@
 # Resources for developers
+
+## Python resources
+### [Python BioImageIO core package](https://github.com/bioimage-io/core-bioimage-io-python)
+
+The `bioimageio.core` is the main package to interact with the BioImageIO contents (*e.g.*, models, datasets, applications). It contains utilities to load and use BioimageIO resources such as processing images with BioImageIO models.
+
+Detailed documentation  on the package can be found on [GitHub](https://bioimage-io.github.io/core-bioimage-io-python/bioimageio/core.html), along with [example notebooks](https://github.com/bioimage-io/core-bioimage-io-python/tree/main/example).
+
+### [Python BioImageIO spec package](https://github.com/bioimage-io/spec-bioimage-io)
+
+The `bioimageio.spec` package enables the interaction with the BioImageIO Resource Description File (RDF) specifications for models, datasets, applications, and notebooks. It is a dependency of the [`bioimageio.core`](https://bioimage-io.github.io/core-bioimage-io-python/bioimageio/core.html). This package contains the utilities for model metadata information handling.
+
+Detailed documentation on the package can be found on [GitHub](https://bioimage-io.github.io/spec-bioimage-io/bioimageio/spec.html), along with [example notebooks](https://github.com/bioimage-io/spec-bioimage-io/tree/main/example_use).
+
+## Java resources
+### [Java BioImageIO library](https://github.com/bioimage-io/JDLL)
+
+Detailed instructions on how to use the Java Deep Learning library can be found in the [Wiki guide](https://github.com/bioimage-io/JDLL/wiki/0.-Home), which also includes a [Quickstart](https://github.com/bioimage-io/JDLL/wiki/II.-Quickstart-for-developers) guide for developers.


### PR DESCRIPTION
Added links and descriptions to the Resources for Developers page, removing the subpages instead directing to github docs