### PR TITLE
Improve prompt for intermediate variable reuse.

### DIFF
--- a/public/chat/index.html
+++ b/public/chat/index.html
@@ -1008,7 +1008,8 @@ The code interperter is a Jupyter notebook-like environment, it support top-leve
 The environment has access to remote servers, so you can fetch remote data by using python modules "requests" or "imjoy_rpc.hypha" for connect to the Hypha/BioEngine server.
 User data will be mounted to the \`/mnt\` directory. Use "os.listdir('/mnt')" to explore available files before processing.
 The code interpreter can produce outputs such as stdout or stderr, matplotlib plots, and image/audio displays which is rendered in the user interface. For key results (e.g. result images), display them in the final response to the user.
-Global variables, functions and results will be maintained across multiple code interpreter executions, so you can reuse them in the next steps.
+Global variables, functions and results will be maintained across multiple code interpreter executions, so try to save the intermediate results into global variables that can be subsequently reused.
+
 
 **Image Processing and Visualization**:
 - For image analysis tasks, you should first inspect the files loaded by the user, then load the image analyse the image type and shape, and process or run the model on the image.

--- a/public/chat/pyodide-worker.js
+++ b/public/chat/pyodide-worker.js
@@ -248,10 +248,10 @@ self.onmessage = async (event) => {
             outputs = []
             // see https://github.com/pyodide/pyodide/blob/b177dba277350751f1890279f5d1a9096a87ed13/src/js/api.ts#L546
             // sync native ==> browser
-            await new Promise((resolve, _) => Module.FS.syncfs(true, resolve));
+            await new Promise((resolve, _) => self.pyodide.FS.syncfs(true, resolve));
             await self.pyodide.runPythonAsync("await run(source, io_context)")
             // sync browser ==> native
-            await new Promise((resolve, _) => Module.FS.syncfs(false, resolve)),
+            await new Promise((resolve, _) => self.pyodide.FS.syncfs(false, resolve)),
             console.log("Execution done", outputs)
             self.postMessage({ executionDone: true, outputs })
             outputs = []

--- a/public/chat/pyodide-worker.js
+++ b/public/chat/pyodide-worker.js
@@ -246,8 +246,12 @@ self.onmessage = async (event) => {
             self.pyodide.globals.set("source", source)
             self.pyodide.globals.set("io_context", io_context && self.pyodide.toPy(io_context))
             outputs = []
+            // copy mounted files into pyodide
+            for(const mountPoint of Object.keys(mountedFs)){
+                await mountedFs[mountPoint].syncfs(true)
+            }
             await self.pyodide.runPythonAsync("await run(source, io_context)")
-            // synchronize the file system
+            // copy files back to the native fs
             for(const mountPoint of Object.keys(mountedFs)){
                 await mountedFs[mountPoint].syncfs()
             }


### PR DESCRIPTION
Added the following prompt for the code interpreter: `try to save the intermediate results into global variables that can be subsequently reused`

This sentence is introduce as suggested by @ctrueden: https://github.com/bioimage-io/bioimageio-chatbot/issues/119
