### PR TITLE
Fix broken links on About page buttons

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -33,12 +33,12 @@
     <br />
     <section style="text-align: center;">
       <b-button
-        @click="openUrl('/docs/#/contribute_models/README')"
+        @click="openUrl('/docs/#/guides/developers-guide')"
         v-if="siteConfig.contribute_url"
         >Contribute Models</b-button
       >
       <b-button
-        @click="openUrl('/docs/#/community_partners/README')"
+        @click="openUrl('/docs/#/guides/community-partners-guide')"
         v-if="siteConfig.join_partners_url"
         >Join Community Partners</b-button
       >


### PR DESCRIPTION
I noticed a couple of 404s from the About page buttons. I tried to update them to current doc pages that seemed appropriate.