### PR TITLE
Switch the collection to s3

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -13,7 +13,7 @@
   "og_image": "https://bioimage.io/static/img/bioimage-io-banner.png",
   "og_description": "Advanced AI models in one-click",
   "background_image": "static/img/zoo-background.svg",
-  "manifest_url": "https://bioimage-io.github.io/collection-bioimage-io/collection.json",
+  "manifest_url": "https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/collection.json",
   "explore_button_text": "🚀 Explore the Zoo",
   "subscribe_url": "https://docs.google.com/forms/d/e/1FAIpQLSfQhTjXOuTXZNtalprbsXMPd4ct2ydiMhlPc2lhcs6WY4yo0w/viewform?embedded=true",
   "contact_form_url": "https://oeway.typeform.com/to/K3j2tJt7",


### PR DESCRIPTION
This PR will switch to the new collection which means all the models will be downloaded from EBI s3.

Please use this link to see if it works: https://bioimage.io/#/?repo=https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/collection.json

Note: the preview link generated by netlify below won't work because of CORS issues.