### PR TITLE
Replaces collection-bioimage-io with newer collection repo in docs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -545,7 +545,7 @@ api.export(new ImJoyPlugin())
 Note that in order to contribute resources to the BioImage.IO Model Zoo you do not need to become a community partner. How to contribute resources is described [here](/contribute_models/README.md). The role of a community partner is described [here](/community_partners/README.md).
 
 
-If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection-bioimage-io/issues/new) with relevant information including the following:
+If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection/issues/new) with relevant information including the following:
 1. Description of your software, organization, company or team.
 2. Description of the resources that you plan to contribute. Please also include the url to your project repo.
 3. Description of future plans on how your project will be maintained.

--- a/docs/guides/community-partners-guide.md
+++ b/docs/guides/community-partners-guide.md
@@ -170,7 +170,7 @@ api.export(new ImJoyPlugin())
 
 Note that in order to contribute resources to the BioImage.IO Model Zoo you do not need to become a community partner. How to contribute resources is described [in the developers guide](https://bioimage.io/docs/#/guides/developers-guide). The role of a community partner is described above.
 
-If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection-bioimage-io/issues/new) with relevant information including the following:
+If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection/issues/new) with relevant information including the following:
 1. Description of your software, organization, company or team.
 2. Description of the resources that you plan to contribute. Please also include the url to your project repo.
 3. Description of future plans on how your project will be maintained.

--- a/docs/guides/community_partners_guide/README.md
+++ b/docs/guides/community_partners_guide/README.md
@@ -171,7 +171,7 @@ api.export(new ImJoyPlugin())
 Note that in order to contribute resources to the BioImage.IO Model Zoo you do not need to become a community partner. How to contribute resources is described [here](/contribute_models/README.md). The role of a community partner is described [here](/community_partners/README.md).
 
 
-If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection-bioimage-io/issues/new) with relevant information including the following:
+If you are eligible and willing to join as a community partner, please submit a request issue [here](https://github.com/bioimage-io/collection/issues/new) with relevant information including the following:
 1. Description of your software, organization, company or team.
 2. Description of the resources that you plan to contribute. Please also include the url to your project repo.
 3. Description of future plans on how your project will be maintained.


### PR DESCRIPTION
As discussed in #425, the documentation for opening a new issue for new community partners should point to  [bioimage-io/collection](https://github.com/bioimage-io/collection). This PR implements that.

I did not change the other places where the user is redirected to [bioimage-io/collection-bioimage-io](https://github.com/bioimage-io/collection-bioimage-io/issues), should I change those too? 